### PR TITLE
wrap the children of <mask> in a <g> (#98)

### DIFF
--- a/packages/gerber-to-svg/lib/_util.js
+++ b/packages/gerber-to-svg/lib/_util.js
@@ -27,7 +27,7 @@ var createMask = function(maskId, box, children, element) {
   children = [boundingRect(box, '#fff', element)].concat(children)
   var attributes = {id: maskId, fill: '#000', stroke: '#000'}
 
-  return element('mask', attributes, children)
+  return element('mask', attributes, [element('g', {}, children)])
 }
 
 module.exports = {


### PR DESCRIPTION
Simply wrap the children of `<mask>` elements in a `<g>`, make SVGs compatible with Inkscape 0.9.2.